### PR TITLE
Rule `no-test-arrow` disallows arrow functions in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+---
+git:
+  depth: 1
+sudo: false
+language: node_js
+cache:
+  directories:
+  - node_modules
+
+node_js:
+- '6'
+- '4'
+
+script:
+- npm test

--- a/README.md
+++ b/README.md
@@ -48,4 +48,6 @@ Then configure the rules you want to use under the rules section.
     * `imports`: deprecated libraries and their replacements
     * `expressions`: deprecated member expressions and their replacements
 
+* `no-test-arrow`: Disallows arrow functions as arguments to Jasmine test functions (`describe`, `it`, `beforeEach`, `beforeAll`, `afterEach`, `afterAll`).
+
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@
 
 module.exports = {
   rules: {
-    'no-deprecated': require('./rules/no-deprecated')
+    'no-deprecated': require('./rules/no-deprecated'),
+    'no-test-arrow': require('./rules/no-test-arrow')
   }
 };

--- a/lib/rules/no-test-arrow.js
+++ b/lib/rules/no-test-arrow.js
@@ -1,0 +1,36 @@
+/**
+ * @fileoverview Rule that disallows passing arrow functions as arguments to Jasmine test functions
+ */
+
+'use strict';
+
+module.exports = {
+  meta: {
+    schema: []
+  },
+
+  create(context) {
+    function report(node, callee) {
+      context.report({
+        node,
+        message: 'Do not use arrow functions in {{callee}}()',
+        data: {
+          callee
+        }
+      });
+    }
+
+    return {
+
+      CallExpression(node) {
+        const testFunctions = ['describe', 'it', 'beforeEach', 'beforeAll', 'afterEach', 'afterAll'];
+
+        if (testFunctions.indexOf(node.callee.name) > -1 &&
+            node.arguments.some(arg => arg.type === 'ArrowFunctionExpression')
+        ) {
+          report(node, node.callee.name);
+        }
+      }
+    };
+  }
+};

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "devDependencies": {
     "eslint": "^3.1.1",
-    "eslint-preset-behance": "^3.0.1"
+    "eslint-preset-behance": "^3.0.1",
+    "mocha": "^3.0.2"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/tests/lib/rules/no-test-arrow.js
+++ b/tests/lib/rules/no-test-arrow.js
@@ -1,0 +1,65 @@
+'use strict';
+
+var rule = require('../../../lib/rules/no-test-arrow');
+var RuleTester = require('eslint').RuleTester;
+var ruleTester = new RuleTester();
+var parserOptions = {
+  ecmaVersion: 6,
+  sourceType: 'module'
+};
+
+ruleTester.run('no-test-arrow', rule, {
+  valid: [
+    'describe(\'foo\', function() {})',
+    'it(\'foo\', function() {})',
+    'beforeEach(function() {})',
+    'beforeAll(function() {})',
+    'afterEach(function() {})',
+    'afterAll(function() {})'
+  ],
+
+  invalid: [
+    {
+      code: 'describe(\'foo\', () => {})',
+      parserOptions,
+      errors: [
+        { message: 'Do not use arrow functions in describe()' }
+      ]
+    },
+    {
+      code: 'it(\'foo\', () => {})',
+      parserOptions,
+      errors: [
+        { message: 'Do not use arrow functions in it()' }
+      ]
+    },
+    {
+      code: 'beforeEach(() => {})',
+      parserOptions,
+      errors: [
+        { message: 'Do not use arrow functions in beforeEach()' }
+      ]
+    },
+    {
+      code: 'beforeAll(() => {})',
+      parserOptions,
+      errors: [
+        { message: 'Do not use arrow functions in beforeAll()' }
+      ]
+    },
+    {
+      code: 'afterEach(() => {})',
+      parserOptions,
+      errors: [
+        { message: 'Do not use arrow functions in afterEach()' }
+      ]
+    },
+    {
+      code: 'afterAll(() => {})',
+      parserOptions,
+      errors: [
+        { message: 'Do not use arrow functions in afterAll()' }
+      ]
+    },
+  ]
+});


### PR DESCRIPTION
ref: https://github.com/adobe-community/issues/issues/11412